### PR TITLE
Add exponential backoff with jitter for Solax cloud and Open-Meteo APIs

### DIFF
--- a/HomeAutomation.CloudInverter/ServiceCollectionExtensions.cs
+++ b/HomeAutomation.CloudInverter/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using HomeAutomation.CloudInverter.ApiAccessor;
 using HomeAutomation.CloudInverter.RealTimeData;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
+using Polly;
 
 namespace HomeAutomation.CloudInverter;
 
@@ -19,8 +20,13 @@ public static class ServiceCollectionExtensions
         })
         .AddStandardResilienceHandler(options =>
         {
+            // Exponential backoff with jitter handles 429 (TooManyRequests) and transient errors.
+            // MaxDelay caps the wait so a page load doesn't hang indefinitely.
             options.Retry.MaxRetryAttempts = 3;
+            options.Retry.BackoffType = DelayBackoffType.Exponential;
+            options.Retry.UseJitter = true;
             options.Retry.Delay = TimeSpan.FromSeconds(2);
+            options.Retry.MaxDelay = TimeSpan.FromSeconds(30);
             options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(60);
         });
 

--- a/HomeAutomation.MetOffice/ServiceCollectionExtensions.cs
+++ b/HomeAutomation.MetOffice/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using HomeAutomation.MetOffice.ApiAccessor;
 using HomeAutomation.MetOffice.WeatherForecast;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
+using Polly;
 
 namespace HomeAutomation.MetOffice;
 
@@ -19,8 +20,13 @@ public static class ServiceCollectionExtensions
         })
         .AddStandardResilienceHandler(options =>
         {
+            // Exponential backoff with jitter handles 429 (TooManyRequests) and transient errors.
+            // MaxDelay caps the wait so a page load doesn't hang indefinitely.
             options.Retry.MaxRetryAttempts = 3;
+            options.Retry.BackoffType = DelayBackoffType.Exponential;
+            options.Retry.UseJitter = true;
             options.Retry.Delay = TimeSpan.FromSeconds(2);
+            options.Retry.MaxDelay = TimeSpan.FromSeconds(30);
             options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(60);
         });
 


### PR DESCRIPTION
- BackoffType: Exponential (was implicit/fixed)
- UseJitter: true to avoid thundering herd
- MaxDelay: 30s cap so page loads don't hang indefinitely
- Retry on 429 TooManyRequests already handled by StandardResilienceHandler

Closes #22