### PR TITLE
Add dark dashboard as default route with auto-refresh and suggestions

### DIFF
--- a/HomeAutomation.Application/BatteryData/GetBatteryData.cs
+++ b/HomeAutomation.Application/BatteryData/GetBatteryData.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace HomeAutomation.Application.BatteryData;
 
-public record BatteryDataResult(BatteryInfo BatteryInfo, string DataSource);
+public record BatteryDataResult(BatteryInfo BatteryInfo, string DataSource, int SolarInputInW, int HomeUsageInW, int FeedInW);
 
 public class GetBatteryData : IRequest<BatteryDataResult>
 {
@@ -29,7 +29,7 @@ public class GetBatteryData : IRequest<BatteryDataResult>
                 (int)batteryRealtimeData.BatteryPercentage,
                 _batteryOptions.CapacityInWh);
 
-            return new BatteryDataResult(batteryInfo, batteryRealtimeData.Source);
+            return new BatteryDataResult(batteryInfo, batteryRealtimeData.Source, (int)batteryRealtimeData.SolarInput, (int)batteryRealtimeData.HomeUsage, (int)batteryRealtimeData.FeedIn);
         }
     }
 }

--- a/HomeAutomation.Web/ClientApp/src/app/app.component.html
+++ b/HomeAutomation.Web/ClientApp/src/app/app.component.html
@@ -1,6 +1,6 @@
 <body>
-  <app-nav-menu></app-nav-menu>
-  <main class="container">
+  <app-nav-menu *ngIf="showNav"></app-nav-menu>
+  <main [class.container]="showNav">
     <router-outlet></router-outlet>
   </main>
 </body>

--- a/HomeAutomation.Web/ClientApp/src/app/app.component.ts
+++ b/HomeAutomation.Web/ClientApp/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs/operators';
 
 @Component({
   standalone: false,
@@ -7,4 +9,13 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'app';
+  showNav = true;
+
+  constructor(private router: Router) {
+    this.router.events.pipe(
+      filter(e => e instanceof NavigationEnd)
+    ).subscribe((e: NavigationEnd) => {
+      this.showNav = e.urlAfterRedirects !== '/';
+    });
+  }
 }

--- a/HomeAutomation.Web/ClientApp/src/app/app.module.ts
+++ b/HomeAutomation.Web/ClientApp/src/app/app.module.ts
@@ -10,8 +10,9 @@ import { HomeComponent } from './home/home.component';
 import { CounterComponent } from './counter/counter.component';
 import { BatteryComponent } from './battery/battery.component';
 import { WeatherForecastComponent } from './weather-forecast/weather-forecast.component';
-import {NgOptimizedImage} from "@angular/common";
-import {InverterSettingsComponent} from "./inverter-settings/inverter-settings.component";
+import { NgOptimizedImage } from "@angular/common";
+import { InverterSettingsComponent } from "./inverter-settings/inverter-settings.component";
+import { DashboardComponent } from "./dashboard/dashboard.component";
 
 @NgModule({
   declarations: [
@@ -21,13 +22,15 @@ import {InverterSettingsComponent} from "./inverter-settings/inverter-settings.c
     CounterComponent,
     BatteryComponent,
     WeatherForecastComponent,
-    InverterSettingsComponent
+    InverterSettingsComponent,
+    DashboardComponent
   ],
     imports: [
         BrowserModule,
         FormsModule,
         RouterModule.forRoot([
-            {path: '', component: HomeComponent, pathMatch: 'full'},
+            {path: '', component: DashboardComponent, pathMatch: 'full'},
+            {path: 'home', component: HomeComponent},
             {path: 'counter', component: CounterComponent},
             {path: 'battery', component: BatteryComponent},
             {path: 'weather-forecast', component: WeatherForecastComponent},

--- a/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.css
+++ b/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.css
@@ -1,0 +1,158 @@
+:host {
+  display: block;
+}
+
+.dashboard {
+  background: #1c1c1e;
+  min-height: 100vh;
+  color: #e5e5e7;
+  padding: 1.5rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Summary header */
+.summary-bar {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+  padding: 1rem 1.5rem;
+  background: #2c2c2e;
+  border-radius: 12px;
+  margin-bottom: 1.25rem;
+}
+
+.summary-battery {
+  font-size: 3rem;
+  font-weight: 700;
+  letter-spacing: -1px;
+  color: #ffffff;
+  line-height: 1;
+}
+
+.summary-power {
+  font-size: 1.4rem;
+  color: #a0a0a8;
+}
+
+.summary-power.charging { color: #32d74b; }
+.summary-power.discharging { color: #ff9f0a; }
+
+.summary-weather {
+  font-size: 2rem;
+}
+
+.summary-inverter {
+  font-size: 1rem;
+  color: #a0a0a8;
+  background: #3a3a3c;
+  padding: 4px 10px;
+  border-radius: 6px;
+}
+
+/* Suggestion banner */
+.suggestion-banner {
+  background: #2c2c2e;
+  border-left: 4px solid #32d74b;
+  border-radius: 8px;
+  padding: 0.9rem 1.25rem;
+  font-size: 1.1rem;
+  margin-bottom: 1.25rem;
+  color: #e5e5e7;
+}
+
+.suggestion-banner.warning {
+  border-left-color: #ff453a;
+}
+
+/* Cards */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+@media (max-width: 768px) {
+  .cards { grid-template-columns: 1fr; }
+}
+
+.card-dark {
+  background: #2c2c2e;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  border: none;
+}
+
+.card-dark h3 {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6e6e73;
+  margin-bottom: 0.75rem;
+}
+
+.card-dark .value {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1.1;
+}
+
+.card-dark .sub {
+  font-size: 0.9rem;
+  color: #a0a0a8;
+  margin-top: 0.25rem;
+}
+
+.card-dark .detail {
+  font-size: 0.85rem;
+  color: #6e6e73;
+  margin-top: 0.5rem;
+}
+
+/* Battery bar */
+.battery-bar-bg {
+  background: #3a3a3c;
+  border-radius: 6px;
+  height: 8px;
+  margin-top: 0.75rem;
+  overflow: hidden;
+}
+
+.battery-bar-fill {
+  height: 100%;
+  border-radius: 6px;
+  background: #32d74b;
+  transition: width 0.5s ease;
+}
+
+.battery-bar-fill.low { background: #ff453a; }
+.battery-bar-fill.mid { background: #ff9f0a; }
+
+/* Footer */
+.dashboard-footer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: #6e6e73;
+  padding-top: 0.5rem;
+}
+
+.cloud-badge {
+  background: #3a3a3c;
+  border: 1px solid #ffc107;
+  color: #ffc107;
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+}
+
+.loading-text {
+  color: #6e6e73;
+  font-size: 1.2rem;
+  text-align: center;
+  padding: 4rem;
+}

--- a/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.css
+++ b/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.css
@@ -68,7 +68,7 @@
 /* Cards */
 .cards {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
   margin-bottom: 1.25rem;
 }
@@ -129,6 +129,9 @@
 
 .battery-bar-fill.low { background: #ff453a; }
 .battery-bar-fill.mid { background: #ff9f0a; }
+
+.grid-export { color: #32d74b; }
+.grid-import { color: #ff453a; }
 
 /* Footer */
 .dashboard-footer {

--- a/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.html
+++ b/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.html
@@ -1,0 +1,84 @@
+<div class="dashboard">
+
+  <!-- Loading state -->
+  <div *ngIf="state.isLoading" class="loading-text">Loading...</div>
+
+  <ng-container *ngIf="!state.isLoading">
+
+    <!-- Summary bar -->
+    <div class="summary-bar">
+      <div class="summary-battery">{{ state.battery.percentageCharged }}%</div>
+
+      <div class="summary-power"
+           [class.charging]="state.battery.activityDescription === 'Charging'"
+           [class.discharging]="state.battery.activityDescription === 'Discharging'">
+        {{ powerLabel }}
+      </div>
+
+      <div class="summary-weather">
+        <ng-container *ngIf="state.weather.isSunny">☀️</ng-container>
+        <ng-container *ngIf="!state.weather.isSunny">🌥️</ng-container>
+      </div>
+
+      <div class="summary-inverter" *ngIf="state.inverter.currentSettingName">
+        ⚙ {{ state.inverter.currentSettingName }}
+      </div>
+    </div>
+
+    <!-- Suggestion banner -->
+    <div class="suggestion-banner" [class.warning]="state.battery.percentageCharged < 15">
+      {{ suggestion }}
+    </div>
+
+    <!-- Detail cards -->
+    <div class="cards">
+
+      <!-- Battery card -->
+      <div class="card-dark">
+        <h3>Battery</h3>
+        <div class="value">{{ state.battery.percentageCharged }}%</div>
+        <div class="sub">{{ state.battery.activityDescription }}</div>
+        <div class="battery-bar-bg">
+          <div class="battery-bar-fill"
+               [class.low]="state.battery.percentageCharged < 20"
+               [class.mid]="state.battery.percentageCharged >= 20 && state.battery.percentageCharged < 50"
+               [style.width.%]="state.battery.percentageCharged">
+          </div>
+        </div>
+        <div class="detail" *ngIf="state.battery.timeToCompleteInH > 0">
+          {{ state.battery.activityDescription === 'Charging' ? 'Full in' : 'Empty in' }}
+          ~{{ state.battery.timeToCompleteInH | number:'1.1-1' }}h
+        </div>
+        <div class="detail">{{ state.battery.remainingBatteryCapacityInWh | number }}Wh remaining</div>
+      </div>
+
+      <!-- Weather card -->
+      <div class="card-dark">
+        <h3>Weather</h3>
+        <div class="value" style="font-size:3rem">
+          <ng-container *ngIf="state.weather.isSunny">☀️</ng-container>
+          <ng-container *ngIf="!state.weather.isSunny">🌥️</ng-container>
+        </div>
+        <div class="sub">{{ state.weather.isSunny ? 'Sunny' : 'Cloudy' }}</div>
+      </div>
+
+      <!-- Inverter card -->
+      <div class="card-dark">
+        <h3>Inverter Mode</h3>
+        <div class="value" style="font-size:1.4rem; padding-top:0.5rem">
+          {{ state.inverter.currentSettingName || 'Unavailable' }}
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Footer -->
+    <div class="dashboard-footer">
+      <span *ngIf="state.lastUpdated">⟳ Updated {{ state.lastUpdated | date:'HH:mm:ss' }}</span>
+      <span>· refreshes every 60s</span>
+      <span class="cloud-badge" *ngIf="isCloudData">⚠ Cloud data</span>
+    </div>
+
+  </ng-container>
+
+</div>

--- a/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.html
+++ b/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.html
@@ -62,11 +62,38 @@
         <div class="sub">{{ state.weather.isSunny ? 'Sunny' : 'Cloudy' }}</div>
       </div>
 
-      <!-- Inverter card -->
+      <!-- Home usage card -->
       <div class="card-dark">
+        <h3>Home Usage</h3>
+        <div class="value">{{ state.battery.homeUsageInW >= 0 ? state.battery.homeUsageInW : 0 }}W</div>
+        <div class="sub">Current consumption</div>
+      </div>
+
+      <!-- Grid card -->
+      <div class="card-dark">
+        <h3>Grid</h3>
+        <ng-container *ngIf="state.battery.feedInW >= 0; else importingGrid">
+          <div class="value grid-export">{{ state.battery.feedInW }}W</div>
+          <div class="sub">{{ state.battery.feedInW > 0 ? 'Exporting' : 'Grid idle' }}</div>
+        </ng-container>
+        <ng-template #importingGrid>
+          <div class="value grid-import">{{ state.battery.feedInW * -1 }}W</div>
+          <div class="sub">Importing from grid</div>
+        </ng-template>
+      </div>
+
+      <!-- Solar card -->
+      <div class="card-dark">
+        <h3>Solar</h3>
+        <div class="value">{{ (state.battery.solarInputInW > 0 ? state.battery.solarInputInW : 0) }}W</div>
+        <div class="sub">{{ state.battery.solarInputInW > 0 ? 'Generating' : 'No generation' }}</div>
+      </div>
+
+      <!-- Inverter card -->
+      <div class="card-dark" *ngIf="inverterAvailable">
         <h3>Inverter Mode</h3>
         <div class="value" style="font-size:1.4rem; padding-top:0.5rem">
-          {{ state.inverter.currentSettingName || 'Unavailable' }}
+          {{ state.inverter.currentSettingName }}
         </div>
       </div>
 

--- a/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.ts
+++ b/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.ts
@@ -15,6 +15,9 @@ interface BatteryData {
   batteryPowerUsageInW: number;
   timeToCompleteInH: number;
   dataSource: string;
+  solarInputInW: number;
+  homeUsageInW: number;
+  feedInW: number;
 }
 
 interface WeatherData {
@@ -24,6 +27,7 @@ interface WeatherData {
 
 interface InverterData {
   isLoading: boolean;
+  isLoaded: boolean;
   timeStamp: Date;
   currentSettingName: string;
 }
@@ -144,5 +148,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   get isCloudData(): boolean {
     return this.state.battery?.dataSource === 'CloudInverter';
+  }
+
+  get inverterAvailable(): boolean {
+    return this.state.inverter?.isLoaded === true;
   }
 }

--- a/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.ts
+++ b/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,148 @@
+import { ChangeDetectorRef, Component, Inject, OnDestroy, OnInit, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { forkJoin } from 'rxjs';
+
+interface BatteryData {
+  isLoading: boolean;
+  totalBatteryCapacityInWh: number;
+  stateDescription: string;
+  timeStamp: Date;
+  percentageCharged: number;
+  remainingChargeInWh: number;
+  remainingBatteryPercentage: number;
+  remainingBatteryCapacityInWh: number;
+  activityDescription: string;
+  batteryPowerUsageInW: number;
+  timeToCompleteInH: number;
+  dataSource: string;
+}
+
+interface WeatherData {
+  isSunny: boolean;
+  isLoading: boolean;
+}
+
+interface InverterData {
+  isLoading: boolean;
+  timeStamp: Date;
+  currentSettingName: string;
+}
+
+interface DashboardState {
+  battery: BatteryData;
+  weather: WeatherData;
+  inverter: InverterData;
+  isLoading: boolean;
+  lastUpdated: Date | null;
+  hasError: boolean;
+}
+
+@Component({
+  standalone: false,
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.css']
+})
+export class DashboardComponent implements OnInit, OnDestroy {
+  private readonly http = inject(HttpClient);
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly refreshIntervalMs = 60_000;
+
+  state: DashboardState = {
+    battery: <BatteryData>{ isLoading: true },
+    weather: <WeatherData>{ isLoading: true },
+    inverter: <InverterData>{ isLoading: true },
+    isLoading: true,
+    lastUpdated: null,
+    hasError: false
+  };
+
+  constructor(
+    @Inject('BASE_URL') private readonly baseUrl: string,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.refresh();
+    this.refreshTimer = setInterval(() => this.refresh(), this.refreshIntervalMs);
+  }
+
+  ngOnDestroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+    }
+  }
+
+  refresh(): void {
+    forkJoin({
+      battery: this.http.get<BatteryData>(this.baseUrl + 'api/battery'),
+      weather: this.http.get<WeatherData>(this.baseUrl + 'api/forecast'),
+      inverter: this.http.get<InverterData>(this.baseUrl + 'api/invertersettings')
+    }).subscribe({
+      next: ({ battery, weather, inverter }) => {
+        this.state = {
+          battery,
+          weather,
+          inverter,
+          isLoading: false,
+          lastUpdated: new Date(),
+          hasError: false
+        };
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        // Partial failures: try individual calls so one failing API doesn't block the rest
+        this.loadIndividually();
+      }
+    });
+  }
+
+  private loadIndividually(): void {
+    this.http.get<BatteryData>(this.baseUrl + 'api/battery').subscribe({
+      next: battery => { this.state.battery = battery; this.state.isLoading = false; this.state.lastUpdated = new Date(); this.cdr.markForCheck(); },
+      error: () => { this.state.battery = <BatteryData>{ isLoading: false }; this.cdr.markForCheck(); }
+    });
+    this.http.get<WeatherData>(this.baseUrl + 'api/forecast').subscribe({
+      next: weather => { this.state.weather = weather; this.cdr.markForCheck(); },
+      error: () => { this.state.weather = <WeatherData>{ isLoading: false }; this.cdr.markForCheck(); }
+    });
+    this.http.get<InverterData>(this.baseUrl + 'api/invertersettings').subscribe({
+      next: inverter => { this.state.inverter = inverter; this.cdr.markForCheck(); },
+      error: () => { this.state.inverter = <InverterData>{ isLoading: false, currentSettingName: 'Unavailable' }; this.cdr.markForCheck(); }
+    });
+  }
+
+  get suggestion(): string {
+    const battery = this.state.battery;
+    const weather = this.state.weather;
+
+    if (!battery || battery.isLoading) return '';
+
+    const pct = battery.percentageCharged;
+    const sunny = weather?.isSunny ?? false;
+    const charging = battery.activityDescription === 'Charging';
+
+    if (pct >= 95) return '🎉 Battery full! Perfect time to run the washing machine or dishwasher.';
+    if (pct < 15) return '⚠️ Battery very low — avoid high-draw appliances like washing machines or tumble dryers.';
+    if (sunny && pct >= 80) return '☀️ Sunny and battery nearly full — great time for washing, dishwasher, or charging devices!';
+    if (sunny && pct >= 40 && charging) return '☀️ Solar charging in progress — good time to run high-draw appliances.';
+    if (sunny && pct < 40) return '☀️ Sunny but battery is low — it\'s charging up. Save heavy loads for later.';
+    if (!sunny && pct >= 70) return '🌥️ Plenty of charge stored — use freely.';
+    if (!sunny && pct >= 30) return '🌥️ Overcast today — use energy conservatively.';
+    if (!sunny && pct < 30) return '🌧️ Battery low and no solar — avoid high-draw appliances.';
+
+    return '✅ System running normally.';
+  }
+
+  get powerLabel(): string {
+    const battery = this.state.battery;
+    if (!battery || battery.isLoading) return '';
+    const w = Math.abs(battery.batteryPowerUsageInW);
+    const direction = battery.activityDescription === 'Charging' ? '↑' : '↓';
+    return `${direction} ${w}W`;
+  }
+
+  get isCloudData(): boolean {
+    return this.state.battery?.dataSource === 'CloudInverter';
+  }
+}

--- a/HomeAutomation.Web/ClientApp/src/styles.css
+++ b/HomeAutomation.Web/ClientApp/src/styles.css
@@ -1,5 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
 
+html, body {
+  margin: 0;
+  padding: 0;
+  background: #1c1c1e;
+}
+
 /* Provide sufficient contrast against white background */
 a {
   color: #0366d6;

--- a/HomeAutomation.Web/Controllers/BatteryController.cs
+++ b/HomeAutomation.Web/Controllers/BatteryController.cs
@@ -40,7 +40,10 @@ public class BatteryController : ControllerBase
                 RemainingBatteryCapacityInWh = batteryInfo.BatteryInfo.BatteryState.RemainingBatteryCapacity,
                 BatteryPowerUsageInW = batteryInfo.BatteryInfo.BatteryActivity.BatteryPowerUsage,
                 TimeStamp = batteryInfo.BatteryInfo.BatteryState.TimeStamp,
-                DataSource = batteryInfo.DataSource
+                DataSource = batteryInfo.DataSource,
+                SolarInputInW = batteryInfo.SolarInputInW,
+                HomeUsageInW = batteryInfo.HomeUsageInW,
+                FeedInW = batteryInfo.FeedInW
             });
         }
         catch (Exception ex)
@@ -64,5 +67,8 @@ public class BatteryController : ControllerBase
         public int BatteryPowerUsageInW { get; init; }
         public DateTime TimeStamp { get; init; }
         public string DataSource { get; init; } = string.Empty;
+        public int SolarInputInW { get; init; }
+        public int HomeUsageInW { get; init; }
+        public int FeedInW { get; init; }
     }
 }


### PR DESCRIPTION
- New DashboardComponent at / — fetches battery, weather, inverter in parallel
- Auto-refreshes every 60 seconds via setInterval; falls back to individual calls on error
- Dark grey theme (#1c1c1e background, #2c2c2e cards) for low-brightness kiosk display
- Summary bar: large battery %, power direction (W), weather emoji, inverter mode pill
- Suggestion banner with 8 rule-based suggestions (sunny, low battery, etc.)
- Battery progress bar (green/amber/red by level) with time-to-complete detail
- Footer: last updated timestamp, 60s refresh note, cloud data badge
- Nav bar hidden on / route only; existing pages kept at /battery /weather-forecast etc.
- Global html/body background set to dark so no white flash on load