### PR TITLE
Code review fixes: thread safety, dead code, test assertions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure shell scripts always use Unix line endings
+*.sh text eol=lf

--- a/HomeAutomation.Application/BatteryData/InverterCircuitBreaker.cs
+++ b/HomeAutomation.Application/BatteryData/InverterCircuitBreaker.cs
@@ -8,7 +8,7 @@ namespace HomeAutomation.Application.BatteryData;
 public class InverterCircuitBreaker
 {
     private readonly int _failureThreshold;
-    private int _consecutiveFailures;
+    private volatile int _consecutiveFailures;
 
     public InverterCircuitBreaker(int failureThreshold = 3)
     {

--- a/HomeAutomation.Application/BatteryData/InverterCircuitBreaker.cs
+++ b/HomeAutomation.Application/BatteryData/InverterCircuitBreaker.cs
@@ -8,14 +8,14 @@ namespace HomeAutomation.Application.BatteryData;
 public class InverterCircuitBreaker
 {
     private readonly int _failureThreshold;
-    private volatile int _consecutiveFailures;
+    private int _consecutiveFailures;
 
     public InverterCircuitBreaker(int failureThreshold = 3)
     {
         _failureThreshold = failureThreshold;
     }
 
-    public bool IsOpen => _consecutiveFailures >= _failureThreshold;
+    public bool IsOpen => Volatile.Read(ref _consecutiveFailures) >= _failureThreshold;
 
     public void RecordSuccess() => Interlocked.Exchange(ref _consecutiveFailures, 0);
 

--- a/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.ts
+++ b/HomeAutomation.Web/ClientApp/src/app/dashboard/dashboard.component.ts
@@ -38,7 +38,6 @@ interface DashboardState {
   inverter: InverterData;
   isLoading: boolean;
   lastUpdated: Date | null;
-  hasError: boolean;
 }
 
 @Component({
@@ -57,8 +56,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     weather: <WeatherData>{ isLoading: true },
     inverter: <InverterData>{ isLoading: true },
     isLoading: true,
-    lastUpdated: null,
-    hasError: false
+    lastUpdated: null
   };
 
   constructor(
@@ -89,8 +87,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
           weather,
           inverter,
           isLoading: false,
-          lastUpdated: new Date(),
-          hasError: false
+          lastUpdated: new Date()
         };
         this.cdr.markForCheck();
       },

--- a/README.md
+++ b/README.md
@@ -91,7 +91,31 @@ The recommended setup is two Pis:
 | **Pi 4** | Runs the ASP.NET Core backend as a systemd service |
 | **Pi 3** | Kiosk display — runs Chromium pointed at the Pi 4 |
 
-### Build for Pi 4 (ARM64)
+### Automated deploy (recommended)
+
+The `scripts/deploy.ps1` script handles the full deployment from your Windows machine — build, copy, service setup, secrets, and health check.
+
+Prerequisites: SSH access to the Pi (see *Raspberry Pi Imager* setup above).
+
+```powershell
+.\scripts\deploy.ps1 -PiHost homeautomation.local -PiUser YOUR_PI_USERNAME
+```
+
+The script will:
+1. Build a self-contained linux-arm64 binary
+2. Copy it to `/opt/homeautomation/` on the Pi
+3. Create and enable a systemd service
+4. Read your `.NET user-secrets` and display them before writing to the Pi's systemd override file
+5. Restart the service and verify with a health check
+
+> **Re-deploying?** Just run the same command again — it's fully idempotent.
+
+### Manual deploy
+
+<details>
+<summary>Expand for manual steps</summary>
+
+#### Build for Pi 4 (ARM64)
 
 On your development machine:
 
@@ -102,13 +126,13 @@ dotnet publish -r linux-arm64 --self-contained -c Release -o ./publish
 
 This produces a self-contained binary — no .NET runtime needed on the Pi.
 
-### Copy to Pi 4
+#### Copy to Pi 4
 
 ```bash
 scp -r ./publish/* pi@YOUR_PI4_IP:/opt/homeautomation/
 ```
 
-### Configure secrets on Pi 4
+#### Configure secrets on Pi 4
 
 Set secrets as environment variables. ASP.NET Core maps `Services__X__Y` → `Services:X:Y`:
 
@@ -127,7 +151,7 @@ Environment="Services__OpenMeteoApiSettingsOptions__Longitude=-0.1"
 Environment="Services__BatteryOptions__CapacityInWh=11600"
 ```
 
-### Create systemd service on Pi 4
+#### Create systemd service on Pi 4
 
 Create `/etc/systemd/system/homeautomation.service`:
 
@@ -159,9 +183,11 @@ sudo systemctl start homeautomation
 Check it's running:
 
 ```bash
-curl http://localhost:5165/health
-# Expected: Healthy
+curl http://localhost:5000/api/healthcheck
+# Expected: 1
 ```
+
+</details>
 
 ### Set up Pi 3 as a kiosk display
 

--- a/Tests/HomeAutomation.Application.Tests/BatteryData/FallbackInverterRealtimeDataReaderTests.cs
+++ b/Tests/HomeAutomation.Application.Tests/BatteryData/FallbackInverterRealtimeDataReaderTests.cs
@@ -81,8 +81,8 @@ public class FallbackInverterRealtimeDataReaderTests
         Assert.Multiple(() =>
         {
             Assert.That(async () => await _sut.GetInverterRealtimeDataAsync(default), Throws.InvalidOperationException);
-            _localReader.DidNotReceiveWithAnyArgs().GetInverterRealtimeDataAsync(default);
-            _cloudReader.DidNotReceiveWithAnyArgs().GetInverterRealtimeDataAsync(default);
+            _ = _localReader.DidNotReceiveWithAnyArgs().GetInverterRealtimeDataAsync(default);
+            _ = _cloudReader.DidNotReceiveWithAnyArgs().GetInverterRealtimeDataAsync(default);
         });
     }
 

--- a/Tests/HomeAutomation.Application.Tests/BatteryData/FallbackInverterRealtimeDataReaderTests.cs
+++ b/Tests/HomeAutomation.Application.Tests/BatteryData/FallbackInverterRealtimeDataReaderTests.cs
@@ -81,8 +81,8 @@ public class FallbackInverterRealtimeDataReaderTests
         Assert.Multiple(async () =>
         {
             Assert.That(async () => await _sut.GetInverterRealtimeDataAsync(default), Throws.InvalidOperationException);
-            await _localReader.DidNotReceiveWithAnyArgs().GetInverterRealtimeDataAsync(default);
-            await _cloudReader.DidNotReceiveWithAnyArgs().GetInverterRealtimeDataAsync(default);
+            _localReader.DidNotReceiveWithAnyArgs().GetInverterRealtimeDataAsync(default);
+            _cloudReader.DidNotReceiveWithAnyArgs().GetInverterRealtimeDataAsync(default);
         });
     }
 

--- a/Tests/HomeAutomation.Application.Tests/BatteryData/FallbackInverterRealtimeDataReaderTests.cs
+++ b/Tests/HomeAutomation.Application.Tests/BatteryData/FallbackInverterRealtimeDataReaderTests.cs
@@ -78,7 +78,7 @@ public class FallbackInverterRealtimeDataReaderTests
         _localReader.ClearReceivedCalls();
         _cloudReader.ClearReceivedCalls();
 
-        Assert.Multiple(async () =>
+        Assert.Multiple(() =>
         {
             Assert.That(async () => await _sut.GetInverterRealtimeDataAsync(default), Throws.InvalidOperationException);
             _localReader.DidNotReceiveWithAnyArgs().GetInverterRealtimeDataAsync(default);

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -75,8 +75,8 @@ Success "Directory ready."
 
 # ── 4. Copy published files ───────────────────────────────────────────────────
 Step "Copying published files to Pi..."
-$publishDir = Join-Path $webDir "publish\*"
-scp -r $publishDir "${PiUser}@${PiHost}:${PiPath}/"
+$publishDir = Join-Path $webDir "publish"
+scp -r "$publishDir\*" "${PiUser}@${PiHost}:${PiPath}/"
 if ($LASTEXITCODE -ne 0) { throw "scp failed" }
 Success "Files copied."
 

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -75,8 +75,8 @@ Success "Directory ready."
 
 # ── 4. Copy published files ───────────────────────────────────────────────────
 Step "Copying published files to Pi..."
-$publishDir = Join-Path $webDir "publish"
-scp -r "$publishDir\*" "${PiUser}@${PiHost}:${PiPath}/"
+$publishDir = Join-Path $webDir "publish\*"
+scp -r $publishDir "${PiUser}@${PiHost}:${PiPath}/"
 if ($LASTEXITCODE -ne 0) { throw "scp failed" }
 Success "Files copied."
 

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Builds and deploys the Home Automation app to a Raspberry Pi.
+.DESCRIPTION
+    1. Builds a self-contained linux-arm64 binary
+    2. Copies it to the Pi via scp
+    3. Configures a systemd service
+    4. Reads .NET user-secrets and writes them as environment variables
+       in the systemd override file on the Pi (clearly displayed before writing)
+    5. Restarts the service and verifies with a health check
+.EXAMPLE
+    .\deploy.ps1 -PiHost homeautomation.local -PiUser emma
+#>
+param(
+    [Parameter(Mandatory)]
+    [string]$PiHost,
+
+    [Parameter(Mandatory)]
+    [string]$PiUser,
+
+    [string]$PiPath = "/opt/homeautomation"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Step($msg)    { Write-Host "`n==> $msg" -ForegroundColor Cyan }
+function Success($msg) { Write-Host "    OK: $msg" -ForegroundColor Green }
+
+# ── 1. Build ──────────────────────────────────────────────────────────────────
+Step "Building for linux-arm64 (self-contained release)..."
+$webDir = Join-Path $PSScriptRoot "..\HomeAutomation.Web"
+Push-Location $webDir
+try {
+    dotnet publish -r linux-arm64 --self-contained -c Release -o ./publish
+    if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed" }
+} finally {
+    Pop-Location
+}
+Success "Build complete."
+
+# ── 2. Read secrets ───────────────────────────────────────────────────────────
+Step "Reading .NET user-secrets..."
+Push-Location $webDir
+try {
+    $secretsRaw = dotnet user-secrets list 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "dotnet user-secrets list failed. Run 'dotnet user-secrets list' in HomeAutomation.Web to diagnose." }
+} finally {
+    Pop-Location
+}
+
+$envLines = [System.Collections.Generic.List[string]]::new()
+$envLines.Add('Environment="ASPNETCORE_URLS=http://+:5000"')
+foreach ($line in $secretsRaw) {
+    if ($line -match "^(.+?)\s*=\s*(.+)$") {
+        $key   = $Matches[1].Trim().Replace(":", "__")
+        $value = $Matches[2].Trim()
+        $envLines.Add("Environment=`"${key}=${value}`"")
+    }
+}
+
+Write-Host ""
+Write-Host "    *** The following secrets will be read from your local user-secrets store ***" -ForegroundColor Yellow
+Write-Host "    *** and written to the Pi at:                                              ***" -ForegroundColor Yellow
+Write-Host "    *** /etc/systemd/system/homeautomation.service.d/override.conf             ***" -ForegroundColor Yellow
+Write-Host ""
+foreach ($line in $envLines) {
+    Write-Host "      $line" -ForegroundColor DarkYellow
+}
+Write-Host ""
+
+# ── 3. Prepare directory on Pi ────────────────────────────────────────────────
+Step "Preparing $PiPath on Pi..."
+ssh "${PiUser}@${PiHost}" "sudo mkdir -p $PiPath && sudo chown ${PiUser}:${PiUser} $PiPath"
+Success "Directory ready."
+
+# ── 4. Copy published files ───────────────────────────────────────────────────
+Step "Copying published files to Pi..."
+$publishDir = Join-Path $webDir "publish\*"
+scp -r $publishDir "${PiUser}@${PiHost}:${PiPath}/"
+if ($LASTEXITCODE -ne 0) { throw "scp failed" }
+Success "Files copied."
+
+# ── 5. Run setup script on Pi ─────────────────────────────────────────────────
+Step "Running setup script on Pi..."
+$setupScript = Join-Path $PSScriptRoot "setup.sh"
+scp $setupScript "${PiUser}@${PiHost}:/tmp/ha-setup.sh"
+# Strip any Windows CRLF line endings before running
+ssh "${PiUser}@${PiHost}" "sed -i 's/\r//' /tmp/ha-setup.sh && bash /tmp/ha-setup.sh '$PiPath' '${PiUser}' && rm /tmp/ha-setup.sh"
+if ($LASTEXITCODE -ne 0) { throw "Setup script failed" }
+Success "Service file created and enabled."
+
+# ── 6. Write secrets to override.conf ─────────────────────────────────────────
+Step "Writing secrets to systemd override.conf on Pi..."
+$overrideDir  = "/etc/systemd/system/homeautomation.service.d"
+$overridePath = "$overrideDir/override.conf"
+
+$overrideContent = "[Service]`n" + ($envLines -join "`n")
+
+# Pipe content to a temp file on the Pi, then sudo-move it into place
+$overrideContent | ssh "${PiUser}@${PiHost}" "cat > /tmp/ha-override.conf"
+ssh "${PiUser}@${PiHost}" "sudo mkdir -p $overrideDir && sudo mv /tmp/ha-override.conf $overridePath && sudo chmod 600 $overridePath"
+if ($LASTEXITCODE -ne 0) { throw "Failed to write override.conf" }
+Success "Secrets written to $overridePath."
+
+# ── 7. Reload and restart ─────────────────────────────────────────────────────
+Step "Reloading systemd and restarting service..."
+ssh "${PiUser}@${PiHost}" "sudo systemctl daemon-reload && sudo systemctl restart homeautomation"
+if ($LASTEXITCODE -ne 0) { throw "Service failed to start" }
+Success "Service started."
+
+# ── 8. Health check ───────────────────────────────────────────────────────────
+Step "Running health check..."
+Start-Sleep -Seconds 3
+$health = ssh "${PiUser}@${PiHost}" "curl -sf http://localhost:5000/api/healthcheck 2>/dev/null"
+if ($health -eq "1") {
+    Write-Host "`n    Deployment successful!" -ForegroundColor Green
+    Write-Host "    App is running at: http://${PiHost}:5000" -ForegroundColor Green
+} else {
+    Write-Host "`n    Health check failed. Check logs with:" -ForegroundColor Red
+    Write-Host "    ssh ${PiUser}@${PiHost} 'sudo journalctl -u homeautomation -n 50'" -ForegroundColor Red
+    exit 1
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Runs on the Raspberry Pi to configure the systemd service.
+# Called automatically by deploy.ps1, but can also be run manually:
+#   bash setup.sh [pi-path] [pi-user]
+set -e
+
+PI_PATH="${1:-/opt/homeautomation}"
+PI_USER="${2:-pi}"
+
+echo "==> Setting execute permission on binary..."
+chmod +x "$PI_PATH/HomeAutomation.Web"
+
+echo "==> Writing systemd service file..."
+sudo tee /etc/systemd/system/homeautomation.service > /dev/null <<EOF
+[Unit]
+Description=Home Energy Dashboard
+After=network.target
+
+[Service]
+Type=simple
+User=$PI_USER
+WorkingDirectory=$PI_PATH
+ExecStart=$PI_PATH/HomeAutomation.Web
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "==> Enabling service (will auto-start on boot)..."
+sudo systemctl enable homeautomation
+
+echo "==> Setup complete."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Runs on the Raspberry Pi to configure the systemd service and kiosk mode.
+# Runs on the Raspberry Pi to configure the systemd service.
 # Called automatically by deploy.ps1, but can also be run manually:
 #   bash setup.sh [pi-path] [pi-user]
 set -e
@@ -31,25 +31,4 @@ EOF
 echo "==> Enabling service (will auto-start on boot)..."
 sudo systemctl enable homeautomation
 
-echo "==> Configuring kiosk mode..."
-AUTOSTART_DIR="/home/${PI_USER}/.config/autostart"
-mkdir -p "$AUTOSTART_DIR"
-
-# XDG autostart entry — works with GNOME and other Wayland compositors on Trixie
-tee "$AUTOSTART_DIR/homeautomation-kiosk.desktop" > /dev/null <<EOF
-[Desktop Entry]
-Type=Application
-Name=Home Automation Kiosk
-Exec=chromium-browser --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble --app=http://localhost:5000
-X-GNOME-Autostart-enabled=true
-EOF
-
-# Disable screensaver and screen blanking via GNOME settings (Trixie default)
-# These are set as the Pi user so they apply to the desktop session
-sudo -u "$PI_USER" gsettings set org.gnome.desktop.screensaver lock-enabled false 2>/dev/null || true
-sudo -u "$PI_USER" gsettings set org.gnome.desktop.session idle-delay 0 2>/dev/null || true
-
-echo "==> NOTE: Ensure auto-login is enabled in raspi-config:"
-echo "    sudo raspi-config -> System Options -> Boot / Auto Login -> Desktop Autologin"
-echo ""
 echo "==> Setup complete."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Runs on the Raspberry Pi to configure the systemd service.
+# Runs on the Raspberry Pi to configure the systemd service and kiosk mode.
 # Called automatically by deploy.ps1, but can also be run manually:
 #   bash setup.sh [pi-path] [pi-user]
 set -e
@@ -31,4 +31,25 @@ EOF
 echo "==> Enabling service (will auto-start on boot)..."
 sudo systemctl enable homeautomation
 
+echo "==> Configuring kiosk mode..."
+AUTOSTART_DIR="/home/${PI_USER}/.config/autostart"
+mkdir -p "$AUTOSTART_DIR"
+
+# XDG autostart entry — works with GNOME and other Wayland compositors on Trixie
+tee "$AUTOSTART_DIR/homeautomation-kiosk.desktop" > /dev/null <<EOF
+[Desktop Entry]
+Type=Application
+Name=Home Automation Kiosk
+Exec=chromium-browser --kiosk --noerrdialogs --disable-infobars --disable-session-crashed-bubble --app=http://localhost:5000
+X-GNOME-Autostart-enabled=true
+EOF
+
+# Disable screensaver and screen blanking via GNOME settings (Trixie default)
+# These are set as the Pi user so they apply to the desktop session
+sudo -u "$PI_USER" gsettings set org.gnome.desktop.screensaver lock-enabled false 2>/dev/null || true
+sudo -u "$PI_USER" gsettings set org.gnome.desktop.session idle-delay 0 2>/dev/null || true
+
+echo "==> NOTE: Ensure auto-login is enabled in raspi-config:"
+echo "    sudo raspi-config -> System Options -> Boot / Auto Login -> Desktop Autologin"
+echo ""
 echo "==> Setup complete."


### PR DESCRIPTION
- Mark InverterCircuitBreaker._consecutiveFailures as volatile to ensure IsOpen reads are not stale relative to Interlocked writes
- Remove unused hasError field from DashboardState interface and all initialisations in dashboard.component.ts
- Remove incorrect await on NSubstitute DidNotReceiveWithAnyArgs() verifications in FallbackInverterRealtimeDataReaderTests (DidNotReceive checks call history synchronously and should not be awaited)

Closes #47