### PR TITLE
Serve Angular SPA from wwwroot/browser/ for Angular 17+ output structure

### DIFF
--- a/HomeAutomation.Web/Program.cs
+++ b/HomeAutomation.Web/Program.cs
@@ -46,6 +46,15 @@ if (!app.Environment.IsDevelopment())
     app.UseHttpsRedirection();
 }
 app.UseStaticFiles();
+
+// Angular 17+ outputs to wwwroot/browser/ — serve those files at the root path
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(
+        Path.Combine(builder.Environment.WebRootPath, "browser")),
+    RequestPath = ""
+});
+
 app.UseRouting();
 
 
@@ -53,6 +62,6 @@ app.MapControllerRoute(
     name: "default",
     pattern: "{controller}/{action=Index}/{id?}");
 
-app.MapFallbackToFile("index.html");
+app.MapFallbackToFile("browser/index.html");
 
 app.Run();


### PR DESCRIPTION
Angular 17+ outputs the built app to dist/browser/ which publishes to wwwroot/browser/. Add a second StaticFileOptions middleware to serve those files at the root path, and update MapFallbackToFile accordingly.

Closes #34