### PR TITLE
Add test requirement to Pi deployment pipeline

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -6,7 +6,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore
+
+    - name: Run tests
+      run: dotnet test --no-build --verbosity normal
+
   build-and-deploy:
+    needs: test
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Add required test step to ensure tests pass before deploying to Raspberry Pi.

The deployment workflow now runs all tests first, and only builds and deploys if tests pass.

Closes #66