### PR TITLE
Switch to pull-based deployment for Raspberry Pi

### DIFF
--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -1,4 +1,4 @@
-name: Deploy to Raspberry Pi
+name: Build and Release for Raspberry Pi
 
 on:
   push:
@@ -26,9 +26,11 @@ jobs:
     - name: Run tests
       run: dotnet test --no-build --verbosity normal
 
-  build-and-deploy:
+  build-and-release:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v3
@@ -49,28 +51,13 @@ jobs:
           --self-contained \
           -o ./publish
 
-    - name: Install SSH dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y openssh-client
+    - name: Package release
+      run: tar -czf homeautomation-desktop-linux-arm.tar.gz -C ./publish .
 
-    - name: Setup SSH key
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ secrets.PI_SSH_KEY }}" > ~/.ssh/id_deploy
-        chmod 600 ~/.ssh/id_deploy
-        ssh-keyscan -H ${{ secrets.PI_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-
-    - name: Deploy to Pi
-      run: |
-        # Upload the published app
-        scp -i ~/.ssh/id_deploy -r ./publish/* ${{ secrets.PI_USER }}@${{ secrets.PI_HOST }}:/opt/homeautomation/
-
-        # Restart the service
-        ssh -i ~/.ssh/id_deploy ${{ secrets.PI_USER }}@${{ secrets.PI_HOST }} \
-          'sudo systemctl restart homeautomation'
-
-    - name: Verify deployment
-      run: |
-        ssh -i ~/.ssh/id_deploy ${{ secrets.PI_USER }}@${{ secrets.PI_HOST }} \
-          'sudo systemctl status homeautomation'
+    - name: Create release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: pi-${{ github.run_number }}
+        name: Pi build ${{ github.run_number }}
+        files: homeautomation-desktop-linux-arm.tar.gz
+        make_latest: true

--- a/scripts/homeautomation-update.service
+++ b/scripts/homeautomation-update.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Pull latest Home Automation Desktop release from GitHub
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/homeautomation-scripts/pi-pull-update.sh

--- a/scripts/homeautomation-update.timer
+++ b/scripts/homeautomation-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodically check for Home Automation Desktop updates
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/pi-pull-update.sh
+++ b/scripts/pi-pull-update.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Runs on the Raspberry Pi via systemd timer.
+# Checks GitHub for the latest Pi release, and if newer than what's installed,
+# downloads and deploys it.
+set -e
+
+REPO="emma-cogensoft/HomeAutomation"
+APP_DIR="/opt/homeautomation"
+VERSION_FILE="$APP_DIR/.deployed-release"
+
+LATEST_TAG=$(curl -sf "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+
+if [ -z "$LATEST_TAG" ]; then
+    echo "Failed to fetch latest release tag"
+    exit 1
+fi
+
+CURRENT_TAG=""
+if [ -f "$VERSION_FILE" ]; then
+    CURRENT_TAG=$(cat "$VERSION_FILE")
+fi
+
+if [ "$LATEST_TAG" == "$CURRENT_TAG" ]; then
+    echo "Already up to date ($CURRENT_TAG)"
+    exit 0
+fi
+
+echo "Updating from '$CURRENT_TAG' to '$LATEST_TAG'..."
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ASSET_URL="https://github.com/$REPO/releases/download/$LATEST_TAG/homeautomation-desktop-linux-arm.tar.gz"
+curl -sfL "$ASSET_URL" -o "$TMP_DIR/release.tar.gz"
+
+systemctl stop homeautomation
+
+# Preserve config that isn't part of the release
+cp "$APP_DIR/appsettings.json" "$TMP_DIR/appsettings.json" 2>/dev/null || true
+
+find "$APP_DIR" -mindepth 1 -delete
+tar -xzf "$TMP_DIR/release.tar.gz" -C "$APP_DIR"
+
+if [ -f "$TMP_DIR/appsettings.json" ]; then
+    cp "$TMP_DIR/appsettings.json" "$APP_DIR/appsettings.json"
+fi
+
+chmod +x "$APP_DIR/HomeAutomation.Desktop"
+echo "$LATEST_TAG" > "$VERSION_FILE"
+
+systemctl start homeautomation
+
+echo "Deployed $LATEST_TAG"

--- a/scripts/pi-setup-pull-deployment.sh
+++ b/scripts/pi-setup-pull-deployment.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# One-time setup on the Raspberry Pi for pull-based deployment.
+# Run as a user with sudo access, e.g.:
+#   bash pi-setup-pull-deployment.sh
+set -e
+
+SCRIPT_DIR="/opt/homeautomation-scripts"
+REPO_RAW="https://raw.githubusercontent.com/emma-cogensoft/HomeAutomation/main/scripts"
+
+echo "==> Creating $SCRIPT_DIR..."
+sudo mkdir -p "$SCRIPT_DIR"
+
+echo "==> Downloading update script and systemd units..."
+sudo curl -sfL "$REPO_RAW/pi-pull-update.sh" -o "$SCRIPT_DIR/pi-pull-update.sh"
+sudo chmod +x "$SCRIPT_DIR/pi-pull-update.sh"
+
+sudo curl -sfL "$REPO_RAW/homeautomation-update.service" -o /etc/systemd/system/homeautomation-update.service
+sudo curl -sfL "$REPO_RAW/homeautomation-update.timer" -o /etc/systemd/system/homeautomation-update.timer
+
+echo "==> Enabling and starting timer..."
+sudo systemctl daemon-reload
+sudo systemctl enable --now homeautomation-update.timer
+
+echo "==> Running first update now..."
+sudo systemctl start homeautomation-update.service
+
+echo "==> Done. Check status with:"
+echo "    systemctl status homeautomation-update.timer"
+echo "    journalctl -u homeautomation-update.service -f"


### PR DESCRIPTION
Replaces push-based SCP deployment (which fails because GitHub Actions can't reach the Pi on the home network) with a pull-based approach.

## How it works
1. On push to main (after tests pass), GitHub Actions builds the ARM32 Desktop app and publishes it as a GitHub Release (tagged `pi-<run_number>`)
2. The Pi runs `pi-pull-update.sh` every 10 minutes via a systemd timer
3. If a newer release is available, it downloads, extracts, and restarts the `homeautomation` service

## Setup on the Pi (one-time, manual)
```bash
curl -sfL https://raw.githubusercontent.com/emma-cogensoft/HomeAutomation/main/scripts/pi-setup-pull-deployment.sh | bash
```

## Cleanup
- PI_HOST, PI_USER, PI_SSH_KEY secrets are no longer used and can be removed from repo settings
- Pi Connect has been disabled on the Pi (no longer needed)

Closes #70