### PR TITLE
Run Avalonia Desktop app via XDG autostart instead of systemd

### DIFF
--- a/scripts/homeautomation-desktop.desktop
+++ b/scripts/homeautomation-desktop.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Application
+Name=Home Automation Dashboard
+Exec=bash -c "sleep 15 && /opt/homeautomation/HomeAutomation.Desktop >> /var/log/homeautomation/app.log 2>&1"
+X-GNOME-Autostart-enabled=true

--- a/scripts/pi-pull-update.sh
+++ b/scripts/pi-pull-update.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-# Runs on the Raspberry Pi via systemd timer.
+# Runs on the Raspberry Pi via systemd timer (as root).
 # Checks GitHub for the latest Pi release, and if newer than what's installed,
-# downloads and deploys it.
+# downloads and deploys it, then (re)launches the app in the desktop session.
 set -e
 
 REPO="emma-cogensoft/HomeAutomation"
 APP_DIR="/opt/homeautomation"
+APP_USER="pi"
 VERSION_FILE="$APP_DIR/.deployed-release"
+LOG_DIR="/var/log/homeautomation"
 
 LATEST_TAG=$(curl -sf "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
 
@@ -33,7 +35,8 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 ASSET_URL="https://github.com/$REPO/releases/download/$LATEST_TAG/homeautomation-desktop-linux-arm.tar.gz"
 curl -sfL "$ASSET_URL" -o "$TMP_DIR/release.tar.gz"
 
-systemctl stop homeautomation
+echo "Stopping running app..."
+pkill -f "$APP_DIR/HomeAutomation.Desktop" || true
 
 # Preserve config that isn't part of the release
 cp "$APP_DIR/appsettings.json" "$TMP_DIR/appsettings.json" 2>/dev/null || true
@@ -46,8 +49,15 @@ if [ -f "$TMP_DIR/appsettings.json" ]; then
 fi
 
 chmod +x "$APP_DIR/HomeAutomation.Desktop"
+chown -R "$APP_USER:$APP_USER" "$APP_DIR"
 echo "$LATEST_TAG" > "$VERSION_FILE"
 
-systemctl start homeautomation
+mkdir -p "$LOG_DIR"
+chown "$APP_USER:$APP_USER" "$LOG_DIR"
+
+echo "Launching app in desktop session..."
+sudo -u "$APP_USER" DISPLAY=:0 XAUTHORITY="/home/$APP_USER/.Xauthority" \
+    "$APP_DIR/HomeAutomation.Desktop" >> "$LOG_DIR/app.log" 2>&1 &
+disown
 
 echo "Deployed $LATEST_TAG"

--- a/scripts/pi-setup-pull-deployment.sh
+++ b/scripts/pi-setup-pull-deployment.sh
@@ -6,6 +6,11 @@ set -e
 
 SCRIPT_DIR="/opt/homeautomation-scripts"
 REPO_RAW="https://raw.githubusercontent.com/emma-cogensoft/HomeAutomation/main/scripts"
+PI_USER="pi"
+
+echo "==> Removing old systemd service (GUI app cannot run headless)..."
+sudo systemctl disable --now homeautomation.service 2>/dev/null || true
+sudo rm -f /etc/systemd/system/homeautomation.service
 
 echo "==> Creating $SCRIPT_DIR..."
 sudo mkdir -p "$SCRIPT_DIR"
@@ -17,6 +22,11 @@ sudo chmod +x "$SCRIPT_DIR/pi-pull-update.sh"
 sudo curl -sfL "$REPO_RAW/homeautomation-update.service" -o /etc/systemd/system/homeautomation-update.service
 sudo curl -sfL "$REPO_RAW/homeautomation-update.timer" -o /etc/systemd/system/homeautomation-update.timer
 
+echo "==> Installing autostart entry for desktop session..."
+AUTOSTART_DIR="/home/${PI_USER}/.config/autostart"
+sudo -u "$PI_USER" mkdir -p "$AUTOSTART_DIR"
+sudo -u "$PI_USER" curl -sfL "$REPO_RAW/homeautomation-desktop.desktop" -o "$AUTOSTART_DIR/homeautomation-desktop.desktop"
+
 echo "==> Enabling and starting timer..."
 sudo systemctl daemon-reload
 sudo systemctl enable --now homeautomation-update.timer
@@ -27,3 +37,8 @@ sudo systemctl start homeautomation-update.service
 echo "==> Done. Check status with:"
 echo "    systemctl status homeautomation-update.timer"
 echo "    journalctl -u homeautomation-update.service -f"
+echo ""
+echo "==> NOTE: Ensure auto-login is enabled in raspi-config:"
+echo "    sudo raspi-config -> System Options -> Boot / Auto Login -> Desktop Autologin"
+echo "    The dashboard will launch automatically after the next reboot/login,"
+echo "    or immediately if a desktop session is already active (15s delay)."


### PR DESCRIPTION
Fixes the `XOpenDisplay failed` crash when the Avalonia app runs as a headless systemd service.

## Changes
- Removed the `homeautomation` systemd service (incompatible with GUI apps)
- Added `homeautomation-desktop.desktop` autostart entry, launched in the `pi` user's desktop session
- `pi-pull-update.sh` now stops/relaunches the app process directly with `DISPLAY=:0` set, rather than using `systemctl`

## Requirements on the Pi
- Auto-login must be enabled: `sudo raspi-config` -> System Options -> Boot/Auto Login -> Desktop Autologin

## To apply
Re-run the setup script, which now also removes the old systemd service and installs the autostart entry:
```bash
curl -sfL https://raw.githubusercontent.com/emma-cogensoft/HomeAutomation/main/scripts/pi-setup-pull-deployment.sh | bash
```

Closes #72