### PR TITLE
Fix dashboard autostart under labwc compositor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Ensure shell scripts always use Unix line endings
 *.sh text eol=lf
+scripts/labwc-autostart text eol=lf

--- a/scripts/homeautomation-desktop.desktop
+++ b/scripts/homeautomation-desktop.desktop
@@ -1,5 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=Home Automation Dashboard
-Exec=bash -c "sleep 15 && /opt/homeautomation/HomeAutomation.Desktop >> /var/log/homeautomation/app.log 2>&1"
-X-GNOME-Autostart-enabled=true

--- a/scripts/labwc-autostart
+++ b/scripts/labwc-autostart
@@ -1,0 +1,12 @@
+#!/bin/bash
+# labwc autostart script - sourced by labwc on session startup.
+# Raspberry Pi OS's default compositor (labwc) does not read XDG
+# ~/.config/autostart/*.desktop files, so the dashboard app is launched here instead.
+
+mkdir -p /var/log/homeautomation
+
+(
+  sleep 15
+  DISPLAY=:0 XAUTHORITY="$HOME/.Xauthority" /opt/homeautomation/HomeAutomation.Desktop \
+    >> /var/log/homeautomation/app.log 2>&1
+) &

--- a/scripts/pi-pull-update.sh
+++ b/scripts/pi-pull-update.sh
@@ -53,7 +53,7 @@ chown -R "$APP_USER:$APP_USER" "$APP_DIR"
 echo "$LATEST_TAG" > "$VERSION_FILE"
 
 mkdir -p "$LOG_DIR"
-chown "$APP_USER:$APP_USER" "$LOG_DIR"
+chown -R "$APP_USER:$APP_USER" "$LOG_DIR"
 
 echo "Launching app in desktop session..."
 sudo -u "$APP_USER" DISPLAY=:0 XAUTHORITY="/home/$APP_USER/.Xauthority" \

--- a/scripts/pi-setup-pull-deployment.sh
+++ b/scripts/pi-setup-pull-deployment.sh
@@ -22,10 +22,18 @@ sudo chmod +x "$SCRIPT_DIR/pi-pull-update.sh"
 sudo curl -sfL "$REPO_RAW/homeautomation-update.service" -o /etc/systemd/system/homeautomation-update.service
 sudo curl -sfL "$REPO_RAW/homeautomation-update.timer" -o /etc/systemd/system/homeautomation-update.timer
 
-echo "==> Installing autostart entry for desktop session..."
-AUTOSTART_DIR="/home/${PI_USER}/.config/autostart"
-sudo -u "$PI_USER" mkdir -p "$AUTOSTART_DIR"
-sudo -u "$PI_USER" curl -sfL "$REPO_RAW/homeautomation-desktop.desktop" -o "$AUTOSTART_DIR/homeautomation-desktop.desktop"
+echo "==> Installing labwc autostart entry for desktop session..."
+LABWC_DIR="/home/${PI_USER}/.config/labwc"
+sudo -u "$PI_USER" mkdir -p "$LABWC_DIR"
+sudo -u "$PI_USER" curl -sfL "$REPO_RAW/labwc-autostart" -o "$LABWC_DIR/autostart"
+sudo -u "$PI_USER" chmod +x "$LABWC_DIR/autostart"
+
+echo "==> Removing old XDG autostart entry (not honored by labwc)..."
+sudo -u "$PI_USER" rm -f "/home/${PI_USER}/.config/autostart/homeautomation-desktop.desktop"
+
+echo "==> Ensuring log directory is owned by ${PI_USER}..."
+sudo mkdir -p /var/log/homeautomation
+sudo chown -R "$PI_USER:$PI_USER" /var/log/homeautomation
 
 echo "==> Enabling and starting timer..."
 sudo systemctl daemon-reload


### PR DESCRIPTION
## Summary
- Raspberry Pi OS's default compositor (labwc) does not read XDG `~/.config/autostart/*.desktop` files — it sources `~/.config/labwc/autostart` (a shell script)
- Replaces the PR #73 XDG autostart entry with a labwc autostart script that launches the dashboard with `DISPLAY=:0`/`XAUTHORITY` after a short delay
- `pi-setup-pull-deployment.sh` now installs this script, removes the old (non-functional) XDG entry, and ensures `/var/log/homeautomation` is owned by `pi`
- `pi-pull-update.sh` now chowns the log directory recursively, fixing a "Permission denied" error writing `app.log`

Confirmed manually on the Pi: app launches on the desktop session and renders live dashboard data (battery, solar, Octopus tariff).

Closes #74

## Test plan
- [x] Manually verified app launches and displays live data via `DISPLAY=:0 XAUTHORITY=/home/pi/.Xauthority`
- [ ] After merge, re-run `pi-setup-pull-deployment.sh` on the Pi and reboot to confirm the labwc autostart launches the app automatically